### PR TITLE
file_get_contents error handling

### DIFF
--- a/src/Klaviyo.php
+++ b/src/Klaviyo.php
@@ -61,8 +61,14 @@ class Klaviyo {
 
     protected function make_request($path, $params) {
         $url = $this->host . $path . '?' . $params;
-        $response = file_get_contents($url);
-        return $response == '1';
+
+        try {
+            $response = file_get_contents($url);
+            return $response == '1';
+
+        } catch (Exception $e) {
+            throw new KlaviyoException('Server could not be reached');
+        }
     }
 };
 


### PR DESCRIPTION
There are cases when Klaviyo servers aren't responding. When this happens regular exception is thrown with file_get_contents error.