### PR TITLE
Fix assignment of special attributes in ProfileModel

### DIFF
--- a/src/Model/ProfileModel.php
+++ b/src/Model/ProfileModel.php
@@ -96,9 +96,8 @@ class ProfileModel extends BaseModel
     protected function setAttributes(array $configuration ) {
         foreach ( $configuration as $key => $value ) {
             if ( $this->isSpecialAttribute($key) ) {
-                $this->{ltrim($key, '$')} = $value;
+                $this->{lcfirst(str_replace('_', '', ucwords(ltrim($key, '$'), '_')))} = $value;
             }
-            
         }
 
         $this->setCustomAttributes( $configuration );


### PR DESCRIPTION
Class properties use camel case but because of a bug in the
`setAttributes` method, special attributes are being assigned
as snake case, e.g. `$first_name` becomes `first_name`, and thus,
it never gets used.

This bug makes the `jsonSerialize` method to always return phone,
first and last name as `null`.

This commit fixes it by properly transforming keys to camel
case.