### PR TITLE
Properly use DateTime to send timestamp

### DIFF
--- a/src/Model/EventModel.php
+++ b/src/Model/EventModel.php
@@ -53,7 +53,7 @@ class EventModel extends BaseModel
             throw new KlaviyoException( $e->getMessage() );
         }
 
-        $this->time = !empty($config['time']) ? strtotime( $time['date'] ) : null;
+        $this->time = !empty($config['time']) ? $time->getTimestamp() : null;
     }
 
     /**


### PR DESCRIPTION
`date` property of `DateTime` is not accessible as an array key.