### PR TITLE
Handle empty response when json_decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### 2.2.2
+- Fix - KlaviyoAPI file to handle json_decode correctly when empty string is returned
+
 ### 2.2.1
 - Fix - Composer file remove comma
 

--- a/src/Klaviyo.php
+++ b/src/Klaviyo.php
@@ -21,7 +21,7 @@ class Klaviyo
     /**
      * @var string
      */
-    const VERSION = '2.2.1';
+    const VERSION = '2.2.2';
 
     /**
      * Constructor for Klaviyo.

--- a/src/KlaviyoAPI.php
+++ b/src/KlaviyoAPI.php
@@ -314,7 +314,9 @@ abstract class KlaviyoAPI
     }
 
     /**
-     * Return decoded json response as associative or empty array.
+     * Return decoded JSON response as associative or empty array.
+     * Certain Klaviyo endpoints (such as Delete) return an empty string on success
+     * and so PHP versions >= 7 will throw a JSON_ERROR_SYNTAX when trying to decode it
      *
      * @param string $response
      * @return mixed
@@ -324,7 +326,6 @@ abstract class KlaviyoAPI
         if (!empty($response)) {
             return json_decode( $response, true );
         }
-        // Delete requests return an empty response
         return json_decode( '{}', true );
     }
 

--- a/src/KlaviyoAPI.php
+++ b/src/KlaviyoAPI.php
@@ -32,7 +32,7 @@ abstract class KlaviyoAPI
     const ERROR_INVALID_API_KEY = 'Invalid API Key.';
     const ERROR_RESOURCE_DOES_NOT_EXIST = 'The requested resource does not exist.';
     const ERROR_NON_200_STATUS = 'Request Failed with HTTP Status Code: %s';
-    
+
     /**
      * Request options
      */
@@ -314,14 +314,17 @@ abstract class KlaviyoAPI
     }
 
     /**
-     * Return decoded json response as associative array.
+     * Return decoded json response as associative or empty array.
      *
      * @param string $response
      * @return mixed
      */
     private function decodeJsonResponse( $response )
     {
-        return json_decode( $response, true );
+        if (!empty($response)) {
+            return json_decode( $response, true );
+        }
+        return json_decode( '{}', true );
     }
 
     /**

--- a/src/KlaviyoAPI.php
+++ b/src/KlaviyoAPI.php
@@ -324,6 +324,7 @@ abstract class KlaviyoAPI
         if (!empty($response)) {
             return json_decode( $response, true );
         }
+        // Delete requests return an empty response
         return json_decode( '{}', true );
     }
 


### PR DESCRIPTION
There are cases where our API returns to us an empty response (Unsubscribe from List being an example). 
Any php version > 7 will throw a `JSON_ERROR_SYNTAX` (4) If an empty string is passed. 
To solve the issue, we should check if the response is empty. If it is, instead of decoding the response we should decode an empty object. To keep the function consistent, I've added true as the second argument to return an empty array. 

The logic has been tested on php 7.3 
I've attached 2 screenshots showing int(4) being returned currently, and 0 (no error) after the update. 

![Screenshot 2020-10-06 at 10 52 07](https://user-images.githubusercontent.com/31895163/95188716-bebd6600-07c4-11eb-82e8-4cea0420797a.png)
![Screenshot 2020-10-06 at 10 50 25](https://user-images.githubusercontent.com/31895163/95188728-c2e98380-07c4-11eb-8e60-90b1572f5369.png)

