### PR TITLE
202010 fix camelcasing issue inside Profile Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## CHANGELOG
 
 ### 2.2.3
-- Fix - ProfileModel file to convert specialAttributes properties to camelCase before running property_exists inside jsonSerialize
+- Fix - ProfileModel file to convert specialAttributes properties to camel case before executing property_exists method inside jsonSerialize
 
 ### 2.2.2
 - Fix - KlaviyoAPI file to handle json_decode correctly when empty string is returned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## CHANGELOG
 
+### 2.2.3
+- Fix - ProfileModel file to convert specialAttributes properties to camelCase before running property_exists inside jsonSerialize
+
 ### 2.2.2
 - Fix - KlaviyoAPI file to handle json_decode correctly when empty string is returned
-- Fix - Fix EventModel unix timestamp issue 
+- Fix - Fix EventModel unix timestamp issue
 - Update - Add all Klaviyo special properties
 
 ### 2.2.1

--- a/src/Klaviyo.php
+++ b/src/Klaviyo.php
@@ -21,7 +21,7 @@ class Klaviyo
     /**
      * @var string
      */
-    const VERSION = '2.2.2';
+    const VERSION = '2.2.3';
 
     /**
      * Constructor for Klaviyo.

--- a/src/Model/ProfileModel.php
+++ b/src/Model/ProfileModel.php
@@ -154,6 +154,7 @@ class ProfileModel extends BaseModel
      * The Special attributes array is using snake case, while class properties are camelCased.
      * This means that variables such as first_name or last_name won't exist on the class object and will
      * simply be missed. To accomodate for that, we convert all the keys to camelCase before running the comparison.
+     *
      * @return string
      */
     public function convertToCamelCase($key) {

--- a/src/Model/ProfileModel.php
+++ b/src/Model/ProfileModel.php
@@ -153,7 +153,7 @@ class ProfileModel extends BaseModel
     /**
      * The Special attributes array is using snake case, while class properties are camelCased.
      * This means that variables such as first_name or last_name won't exist on the class object and will
-     * simply be missed. To accomodate for that, we convert all the keys to camelCase before running the comparison.
+     * simply be missed inside jsonSerialize method. To accomodate for that, we convert all the keys to camelCase before running the comparison.
      *
      * @return string
      */

--- a/src/Model/ProfileModel.php
+++ b/src/Model/ProfileModel.php
@@ -97,9 +97,9 @@ class ProfileModel extends BaseModel
     protected function setAttributes(array $configuration ) {
         foreach ( $configuration as $key => $value ) {
             if ( $this->isSpecialAttribute($key) ) {
-                $this->{lcfirst(str_replace('_', '', ucwords(ltrim($key, '$'), '_')))} = $value;
+                $this->{$this->convertToCamelCase($key)} = $value;
             }
-            
+
         }
 
         $this->setCustomAttributes( $configuration );
@@ -150,14 +150,24 @@ class ProfileModel extends BaseModel
         return $this->customAttributes;
     }
 
+    /**
+     * The Special attributes array is using snake case, while class properties are camelCased.
+     * This means that variables such as first_name or last_name won't exist on the class object and will
+     * simply be missed. To accomodate for that, we convert all the keys to camelCase before running the comparison.
+     * @return string
+     */
+    public function convertToCamelCase($key) {
+        return lcfirst(str_replace('_', '', ucwords(ltrim($key, '$'), '_')));
+    }
+
     public function jsonSerialize() {
         $properties = array_fill_keys($this::$specialAttributes, null);
         foreach ($properties as $key => &$value) {
-            if (!property_exists($this, substr($key, 1))) {
+            if (!property_exists($this, $this->convertToCamelCase($key))) {
                 continue;
             }
 
-            $value = $this->{substr($key, 1)};
+            $value = $this->{$this->convertToCamelCase($key)};
         }
 
         unset($properties['$email']);


### PR DESCRIPTION
The profileModel class has its properties listed using camelCase notation. 
As we are now doing a a property check between '$this' and $properties, the values that use snake_casing such as first_name or last_name will be missed out. 

As the code uses camelCasing across the board, we should keep this consistent and so before checking if property exists, we should do a conversion to camelCase. 

This already happens inside of setAttributes() method, so the PR simply pulls out that logic and puts it in its own function. 
We can then call it before '!property_exists' to make sure all values align. 

<img width="631" alt="Screenshot 2020-10-07 at 10 44 15" src="https://user-images.githubusercontent.com/31895163/95315232-25588780-088a-11eb-9983-02bc84df13c0.png">
<img width="614" alt="Screenshot 2020-10-07 at 10 44 46" src="https://user-images.githubusercontent.com/31895163/95315237-2689b480-088a-11eb-8ba5-a94b76f566b3.png">


