### PR TITLE
Updated apache license to remove Packagist error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### 2.2.6
+- Fix - Composer file Apache license value
+
 ### 2.2.5
 - Update - Add error details into KlaviyoAPI handleResponse function
 - Update - Add KlaviyoApiException 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["klaviyo", "sdk"],
     "type": "library",
     "homepage": "http://github.com/klaviyo",
-    "license": "Apache2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Klaviyo",


### PR DESCRIPTION
- updated to apache license value in composer.json from "Apache2" to "Apache-2.0" to address the Packagist error: 

`License "Apache2" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.`