### PR TITLE
Add gitattributes meta file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,3 @@
 /.gitattributes             export-ignore
 /.gitignore                 export-ignore
 /phpunit.xml                export-ignore
-/CHANGELOG.md               export-ignore
-/README.md                  export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests                      export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/phpunit.xml                export-ignore
+/CHANGELOG.md               export-ignore
+/README.md                  export-ignore


### PR DESCRIPTION
The `.gitattributes` will make sure that when this repos is installed it only downloads files used for using the library and not meta files and tests