### PR TITLE
Update phpunit config to work with code coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
         "psr-4": {
             "Klaviyo\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Klaviyo\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<phpunit
-bootstrap="vendor/autoload.php"
-colors="true"
-verbose="true"
->
-<testsuites>
-    <testsuite name="default">
-        <directory prefix="test-" suffix=".php">tests</directory>
-    </testsuite>
-</testsuites>
-
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php"
+         colors="true" verbose="true">
+    <coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="PHP Klaviyo Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/tests/KlaviyoTest.php
+++ b/tests/KlaviyoTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Klaviyo;
+
 use Klaviyo\Klaviyo;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/ProfilesTest.php
+++ b/tests/ProfilesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Klaviyo;
+
 use Klaviyo\KlaviyoAPI;
 use Klaviyo\Profiles;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This PR allows developers to generate code coverage by running: `vendor/bin/phpunit --coverage-html=build`. Notice that you need xdebug (or some other coverage tool) enabled to run this command.

Here is an image of the current state of code coverage:

![image](https://user-images.githubusercontent.com/2412177/113000819-7af25a80-9170-11eb-8a2d-5e86e6738a94.png)
