### PR TITLE
Deprecate lists and metrics methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## CHANGELOG
+### Unreleased
+- Deprecate - Rename List API methods: getListDetails, updateListDetails, subscribeMembersToList, unsubscribeMembersFromList, getGroupMemberIdentifiers, getAllExclusionsOnList
+- Deprecate - Rename Metric API methods: getMetricTimeline, exportMetricData
 
 ### 2.2.5
 - Update - Add error details into KlaviyoAPI handleResponse function
-- Update - Add KlaviyoApiException 
+- Update - Add KlaviyoApiException
 
 ### 2.2.4
 - Fix - Instantiate KlaviyoRateLimitException properly

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ http://www.klaviyo.com/
 ## How to install?
 
     composer require klaviyo/php-sdk
-    
+
 ## API Examples
 
 After installing the Klaviyo package you can initiate it using your public token which is for track events or identifying profiles and/or your private api key to utilize the metrics and list apis.
@@ -26,32 +26,32 @@ You can then easily use Klaviyo to track events or identify people.  Note, track
 ### Track an event
 ```php
 use Klaviyo\Model\EventModel as KlaviyoEvent;
-    
+
 $event = new KlaviyoEvent(
     array(
         'event' => 'Filled out Profile',
         'customer_properties' => array(
-            '$email' => 'someone@mailinator.com'    
+            '$email' => 'someone@mailinator.com'
         ),
         'properties' => array(
             'Added Social Accounts' => False
         )
     )
 );
-    
-$client->publicAPI->track( $event );    
-```    
+
+$client->publicAPI->track( $event );
+```
 ### You can also add profile properties to the 'customer properties' attribute in the Event model
 ```php
 use Klaviyo\Model\EventModel as KlaviyoEvent;
-        
+
 $event = new KlaviyoEvent(
     array(
         'event' => 'Filled out Profile',
         'customer_properties' => array(
             '$email' => 'someone@mailinator.com',
             '$first_name' => 'Thomas',
-            '$last_name' => 'Jefferson'   
+            '$last_name' => 'Jefferson'
         ),
         'properties' => array(
             'Added Social Accounts' => False
@@ -65,7 +65,7 @@ $client->publicAPI->track( $event );
 ### or just add a property to someone
 ```php
 use Klaviyo\Model\ProfileModel as KlaviyoProfile;
-    
+
 $profile = new KlaviyoProfile(
     array(
         '$email' => 'thomas.jefferson@mailinator.com',
@@ -74,7 +74,7 @@ $profile = new KlaviyoProfile(
         'Plan' => 'Premium'
     )
 );
-    
+
 $client->publicAPI->identify( $profile );
 ```
 
@@ -88,11 +88,11 @@ $client->metrics->getMetrics();
 $client->metrics->getMetricsTimeline();
 
 #return a specific metric timeline using its metric ID
-$client->metrics->getMetricTimeline( 'METRICID' );
+$client->metrics->getMetricTimelineById( 'METRICID' );
 
 #export metric specific values
-$client->metrics->exportMetricData( 'METRICID' );
-``` 
+$client->metrics->getMetricExport( 'METRICID' );
+```
 
 ### You can create, update, read, and delete lists.  See here for more information https://www.klaviyo.com/docs/api/v2/lists
 ```php
@@ -103,22 +103,22 @@ $client->lists->createList( 'List Name' );
 $client->lists->getLists();
 
 #Get information about a list
-$client->lists->getListDetails( 'ListId' );
+$client->lists->getListById( 'ListId' );
 
 #update a lists properties
-$client->lists->updateListDetails( 'ListId', 'ListName' );
+$client->lists->updateListNameById( 'ListId', 'ListName' );
 
 #Delete a list from account
 $client->lists->deleteList( 'ListId' );
 
 #Subscribe or re-subscribe profiles to a list
-$client->lists->subscribeMemberstoList( 'ListId', array $arrayOfProfiles );
+$client->lists->addSubscribersToList( 'ListId', array $arrayOfProfiles );
 
 #Check if profiles are on a list and not suppressed
 $client->lists->checkListSubscriptions( 'ListId', array $emails, array $phoneNumbers, array $pushTokens );
 
 #Unsubscribe and remove profiles from a list
-$client->lists->unsubscribeMembersFromList( 'ListId', array $emails );
+$client->lists->deleteSubscribersFromList( 'ListId', array $emails );
 
 #Add members to list without affecting consent status
 $client->lists->addMembersToList( 'ListId', array $arrayOfProfiles );
@@ -130,10 +130,10 @@ $client->lists->checkListMembership( 'ListId', array $emails, array $phoneNumber
 $client->lists->removeMembersFromList( 'ListId', array $emails );
 
 #Get all exclusions on a list
-$client->lists->getAllExclusionsOnList( 'ListId' );
+$client->lists->getListExclusions( 'ListId' );
 
 #Get all of the emails, phone numbers and push tokens for profiles in a given list or segment
-$client->lists->getGroupMemberIdentifiers( 'GroupId' );
+$client->lists->getAllMembers( 'GroupId' );
 ```
 
 ### You can fetch profile information given the profile ID, See here for more information https://www.klaviyo.com/docs/api/people
@@ -162,7 +162,7 @@ $client->profiles->getProfileMetricTimeline( 'ProfileId', 'MetricId' );
   `{"detail":"Request was throttled. Expected available in 26.0 seconds.","retryAfter":26}`
 
 ### Klaviyo\Exception\KlaviyoAuthenticationException
-  Thrown when there is an authentication error when making an API request, usually caused by an invalid API key.  
+  Thrown when there is an authentication error when making an API request, usually caused by an invalid API key.
 
 ### Klaviyo\Exception\KlaviyoResourceNotFoundException
   Thrown when the system attempts to update a property that doesn't exist. For example, attempting to update a list that doesn't exist on the account.

--- a/src/Lists.php
+++ b/src/Lists.php
@@ -58,6 +58,7 @@ class Lists extends KlaviyoAPI
 
     /**
      * Get information about a list
+     *
      * @deprecated 2.2.6
      * @see getListById
      *
@@ -68,8 +69,7 @@ class Lists extends KlaviyoAPI
      */
     public function getListDetails( $listId )
     {
-        $path = sprintf( '%s/%s', self::ENDPOINT_LIST, $listId );
-        return $this->v2Request( $path );
+        return $this->getListById($listId);
     }
 
     /**

--- a/src/Lists.php
+++ b/src/Lists.php
@@ -11,6 +11,7 @@ class Lists extends KlaviyoAPI
     /**
      * List endpoint constants
      */
+    const ENDPOINT_ALL = 'all';
     const ENDPOINT_EXCLUSIONS = 'exclusions';
     const ENDPOINT_GROUP = 'group';
     const ENDPOINT_LIST = 'list';
@@ -57,9 +58,10 @@ class Lists extends KlaviyoAPI
 
     /**
      * Get information about a list
-     * @link https://www.klaviyo.com/docs/api/v2/lists#get-list
+     * @deprecated 2.2.6
+     * @see getListById
      *
-     * @param $listId
+     * @param string $listId
      * 6 digit unique identifier of the list
      *
      * @return bool|mixed
@@ -71,8 +73,25 @@ class Lists extends KlaviyoAPI
     }
 
     /**
+     * Get information about a list.
+     * @link https://www.klaviyo.com/docs/api/v2/lists#get-list
+     *
+     * @param string $listId
+     * 6 digit unique identifier of the list
+     *
+     * @return bool|mixed
+     */
+    public function getListById($listId)
+    {
+        $path = sprintf('%s/%s', self::ENDPOINT_LIST, $listId);
+        return $this->v2Request($path);
+    }
+
+    /**
      * Update a list's properties
-     * @link https://www.klaviyo.com/docs/api/v2/lists#put-list
+     *
+     * @deprecated 2.2.6
+     * @see updateListNameById
      *
      * @param $listId
      * 6 digit unique identifier of the list
@@ -84,13 +103,30 @@ class Lists extends KlaviyoAPI
      */
     public function updateListDetails( $listId, $list_name )
     {
-        $params = $this->createRequestBody( array(
-            self::LIST_NAME => $list_name
-        ) );
+        return $this->updateListNameById($listId, $list_name);
+    }
 
-        $path = sprintf( '%s/%s', self::ENDPOINT_LIST, $listId );
+    /**
+     * Update a list's name.
+     * @link https://www.klaviyo.com/docs/api/v2/lists#put-list
+     *
+     * @param string $listId
+     * 6 digit unique identifier of the list
+     *
+     * @param string $listName
+     * String to update list name to
+     *
+     * @return bool|mixed
+     */
+    public function updateListNameById($listId, $listName)
+    {
+        $params = $this->createRequestBody(
+            array(self::LIST_NAME => $listName)
+        );
 
-        return $this->v2Request( $path, $params, self::HTTP_PUT );
+        $path = sprintf('%s/%s', self::ENDPOINT_LIST, $listId);
+
+        return $this->v2Request($path, $params, self::HTTP_PUT);
     }
 
     /**
@@ -110,7 +146,9 @@ class Lists extends KlaviyoAPI
 
     /**
      * Subscribe or re-subscribe profiles to a list. Profiles will be single or double opted into the specified list in accordance with that list’s settings.
-     * @link https://www.klaviyo.com/docs/api/v2/lists#post-subscribe
+     *
+     * @deprecated 2.2.6
+     * @see addSubscribersToList
      *
      * @param $listId
      * 6 digit unique identifier of the list
@@ -126,18 +164,40 @@ class Lists extends KlaviyoAPI
      */
     public function subscribeMembersToList( $listId, $profiles )
     {
-        $this->checkProfile( $profiles );
+        return $this->addSubscribersToList($listId, $profiles);
+    }
+
+    /**
+     * Subscribe or re-subscribe profiles to a list. Profiles will be single or double opted into the specified list in accordance with that list’s settings.
+     * @link https://www.klaviyo.com/docs/api/v2/lists#post-subscribe
+     *
+     * @param $listId
+     * 6 digit unique identifier of the list
+     *
+     * @param array $profiles
+     * The profiles that you would like to subscribe. Each object in the list must have either an email or phone number key.
+     * You can also provide additional properties as key-value pairs. If you are a GDPR compliant business, you will need to include $consent in your API call.
+     * $consent is a Klaviyo special property and only accepts the following values: "email", "web", "sms", "directmail", "mobile".
+     * If you are updating consent for a phone number or would like to send an opt-in SMS to the profile (for double opt-in lists), include an sms_consent key in the profile with a value of true or false.
+     *
+     * @return bool|mixed
+     * @throws Exception\KlaviyoException
+     */
+    public function addSubscribersToList($listId, $profiles)
+    {
+        $this->checkProfile($profiles);
 
         $profiles = array_map(
-            function( $profile ) {
+            function($profile) {
                 return $profile->toArray();
-            }, $profiles
+            },
+            $profiles
         );
 
-        $path = sprintf( '%s/%s/%s', self::ENDPOINT_LIST, $listId, self::ENDPOINT_SUBSCRIBE );
-        $params = $this->createParams( self::PROFILES, $profiles );
+        $path = sprintf('%s/%s/%s', self::ENDPOINT_LIST, $listId, self::ENDPOINT_SUBSCRIBE);
+        $params = $this->createParams(self::PROFILES, $profiles);
 
-        return $this->v2Request( $path, $params, self::HTTP_POST );
+        return $this->v2Request($path, $params, self::HTTP_POST);
     }
 
     /**
@@ -178,7 +238,9 @@ class Lists extends KlaviyoAPI
 
     /**
      * Unsubscribe and remove profiles from a list.
-     * @link https://www.klaviyo.com/docs/api/v2/lists#delete-subscribe
+     *
+     * @deprecated 2.2.6
+     * @see deleteSubscribersFromList
      *
      * @param string $listId
      * 6 digit unique identifier of the list
@@ -190,6 +252,23 @@ class Lists extends KlaviyoAPI
      */
     public function unsubscribeMembersFromList( $listId, $emails )
     {
+        return $this->deleteSubscribersFromList($listId, $emails);
+    }
+
+    /**
+     * Unsubscribe and remove profiles from a list.
+     * @link https://www.klaviyo.com/docs/api/v2/lists#delete-subscribe
+     *
+     * @param string $listId
+     * 6 digit unique identifier of the list
+     *
+     * @param array $emails
+     * The emails corresponding to the profiles that you would like to check.
+     *
+     * @return bool|mixed
+     */
+    public function deleteSubscribersFromList($listId, $emails)
+    {
         $params = $this->createRequestJson(
             $this->filterParams(
                 array(
@@ -198,9 +277,9 @@ class Lists extends KlaviyoAPI
             )
         );
 
-        $path = sprintf('%s/%s/%s', self::ENDPOINT_LIST, $listId, self::ENDPOINT_SUBSCRIBE );
+        $path = sprintf('%s/%s/%s', self::ENDPOINT_LIST, $listId, self::ENDPOINT_SUBSCRIBE);
 
-        return $this->v2Request( $path, $params, self::HTTP_DELETE );
+        return $this->v2Request($path, $params, self::HTTP_DELETE);
     }
 
     /**
@@ -302,7 +381,9 @@ class Lists extends KlaviyoAPI
     /**
      * Get all of the emails and phone numbers that have been excluded from a list along with the exclusion reasons and exclusion time.
      * This endpoint uses batching to return the records, so for a large list multiple calls will need to be made to get all of the records.
-     * @link https://www.klaviyo.com/docs/api/v2/lists#get-exclusions-all
+     *
+     * @deprecated 2.2.6
+     * @see getListExclusions
      *
      * @param $listId
      * 6 digit unique identifier of the list
@@ -314,6 +395,24 @@ class Lists extends KlaviyoAPI
      */
     public function getAllExclusionsOnList( $listId, $marker = null )
     {
+        return $this->getListExclusions($listId, $marker);
+    }
+
+    /**
+     * Get all of the emails and phone numbers that have been excluded from a list along with the exclusion reasons and exclusion time.
+     * This endpoint uses batching to return the records, so for a large list multiple calls will need to be made to get all of the records.
+     * @link https://www.klaviyo.com/docs/api/v2/lists#get-exclusions-all
+     *
+     * @param $listId
+     * 6 digit unique identifier of the list
+     *
+     * @param int $marker
+     * A marker value returned by a previous GET call. Use this to grab the next batch of records.
+     *
+     * @return bool|mixed
+     */
+    public function getListExclusions($listId, $marker = null)
+    {
         $params = $this->createRequestBody(
             $this->filterParams(
                 array(
@@ -322,9 +421,29 @@ class Lists extends KlaviyoAPI
             )
         );
 
-        $path = sprintf( '%s/%s/%s/%s',self::ENDPOINT_LIST, $listId, self::ENDPOINT_EXCLUSIONS, 'all' );
+        $path = sprintf('%s/%s/%s/%s',self::ENDPOINT_LIST, $listId, self::ENDPOINT_EXCLUSIONS, self::ENDPOINT_ALL);
 
-        return $this->v2Request( $path, $params );
+        return $this->v2Request($path, $params);
+    }
+
+    /**
+     * Get all of the emails, phone numbers, and push tokens for profiles in a given list or segment.
+     * This endpoint uses batching to return the records, so for a large list or segment multiple calls will need to be made to get all of the records.
+     *
+     * @deprecated 2.2.6
+     * @see getAllMembers
+     *
+     * @param $groupId
+     * 6 digit unique identifier of List/Segment to get member information about
+     *
+     * @param int $marker
+     * A marker value returned by a previous GET call. Use this to grab the next batch of records.
+     *
+     * @return bool|mixed
+     */
+    public function getGroupMemberIdentifiers( $groupId, $marker = null )
+    {
+        return $this->getAllMembers($groupId, $marker);
     }
 
     /**
@@ -340,7 +459,7 @@ class Lists extends KlaviyoAPI
      *
      * @return bool|mixed
      */
-    public function getGroupMemberIdentifiers( $groupId, $marker = null )
+    public function getAllMembers($groupId, $marker = null)
     {
         $params = $this->createRequestBody(
             $this->filterParams(
@@ -350,7 +469,7 @@ class Lists extends KlaviyoAPI
             )
         );
 
-        $path = sprintf( '%s/%s/%s/%s',self::ENDPOINT_GROUP, $groupId, self::ENDPOINT_MEMBERS, 'all' );
-        return $this->v2Request( $path, $params );
+        $path = sprintf('%s/%s/%s/%s',self::ENDPOINT_GROUP, $groupId, self::ENDPOINT_MEMBERS, self::ENDPOINT_ALL);
+        return $this->v2Request($path, $params);
     }
 }

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -86,7 +86,10 @@ class Metrics extends KlaviyoAPI
 
     /**
      * Returns a batched timeline for one specific type of metric, requires metric ID from your Klaviyo account
-     * @link https://www.klaviyo.com/docs/api/metrics#metric-timeline
+     *
+     * @deprecated 2.2.6
+     * @see getMetricTimelineById
+     *
      * @param string $metricID
      * 6 digit unique identifier of the metric
      *
@@ -109,23 +112,55 @@ class Metrics extends KlaviyoAPI
      */
     public function getMetricTimeline( $metricID, $since = null, $uuid = null, $count = null, $sort = null )
     {
-        $params = $this->setSinceParameter( $since, $uuid );
+        return $this->getMetricTimelineById($metricID, $since, $uuid, $count, $sort);
+    }
 
-        $params = $this->filterParams( array_merge(
-            $params,
-            array(
-                self::COUNT => $count,
-                self::SORT => $sort
+    /**
+     * Returns a batched timeline for one specific type of metric, requires metric ID from your Klaviyo account
+     * @link https://www.klaviyo.com/docs/api/metrics#metric-timeline
+     * @param string $metricID
+     * 6 digit unique identifier of the metric
+     *
+     * @param string $since
+     * To be used with the since argument of the call, can accept UNIX timestamps,
+     * The `since` argument of the call defaults to current time
+     *
+     * @param string $uuid
+     * Can be used with the `since` argument of the call, is obtained via the 'next' attribute of a prior API call.
+     * The `since` argument of the call defaults to current time
+     *
+     * @param int $count defaults to 100,
+     * Number of events to return in a batch
+     *
+     * @param string $sort defaults to 'desc'
+     * Sort order to apply to timeline
+     *
+     * @return bool|mixed
+     */
+    public function getMetricTimelineById($metricID, $since = null, $uuid = null, $count = null, $sort = null)
+    {
+        $params = $this->setSinceParameter($since, $uuid);
+
+        $params = $this->filterParams(
+            array_merge(
+                $params,
+                array(
+                    self::COUNT => $count,
+                    self::SORT => $sort
+                )
             )
-        ) );
+        );
 
-        $path = sprintf( '%s/%s/%s', self::METRIC, $metricID, self::TIMELINE );
-        return $this->v1Request( $path, $params );
+        $path = sprintf('%s/%s/%s', self::METRIC, $metricID, self::TIMELINE);
+        return $this->v1Request($path, $params);
     }
 
     /**
      * Export event data from Klaviyo optionally filtering and segmented on available event properties.
-     * @link https://www.klaviyo.com/docs/api/metrics#metric-export
+     *
+     * @deprecated 2.2.6
+     * @see getMetricExport
+     *
      * @param string $metricID
      * 6 digit unique identifier of the metric
      *
@@ -155,8 +190,38 @@ class Metrics extends KlaviyoAPI
                                       $by = null,
                                       $count = null )
     {
-        if (isset( $where ) && isset( $by )) {
-            throw new KlaviyoException('Please use either \'where\' or \'by\', only one of these variables can be set for the export call' );
+        return $this->getMetricExport($metricID, $start_date, $end_date, $unit, $measurement, $where, $by, $count);
+    }
+
+    /**
+     * Export event data from Klaviyo optionally filtering and segmented on available event properties.
+     * @link https://www.klaviyo.com/docs/api/metrics#metric-export
+     *
+     * @param string $metricID 6 digit unique identifier of the metric
+     * @param $start_date
+     * @param $end_date
+     * @param $unit
+     * @param $measurement
+     * @param $where
+     * @param $by
+     * @param $count
+     *
+     * @return bool|mixed
+     * @throws KlaviyoException
+     */
+    public function getMetricExport(
+        $metricID,
+        $start_date = null,
+        $end_date = null,
+        $unit = null,
+        $measurement = null,
+        $where = null,
+        $by = null,
+        $count = null
+    )
+    {
+        if (isset($where) && isset($by)) {
+            throw new KlaviyoException('Please use either \'where\' or \'by\', only one of these variables can be set for the export call');
         }
 
         $params = $this->filterParams(
@@ -167,14 +232,12 @@ class Metrics extends KlaviyoAPI
                 self::MEASUREMENT => $measurement,
                 self::WHERE => $where,
                 self::BY => $by,
-                self::COUNT => $count
+                self::COUNT => $count,
             )
         );
 
-        $path = sprintf( '%s/%s/%s', self::METRIC, $metricID, self::EXPORT );
+        $path = sprintf('%s/%s/%s', self::METRIC, $metricID, self::EXPORT);
 
-        return $this->v1Request( $path, $params );
-
+        return $this->v1Request($path, $params);
     }
-
 }


### PR DESCRIPTION
Renaming and deprecating a bunch of list and metrics API methods to align with our other SDKs. I thought there was only only one or two but we had a bunch. Intentionally did not update checkListSubscriptions because imo getSubscribersFromList isn't any more descriptive. Kinda updated the doc that contains our method names but I wasn't quite certain what our color coding convention meant.