### PR TITLE
add API call for excluding profile from all email

### DIFF
--- a/src/Profiles.php
+++ b/src/Profiles.php
@@ -14,6 +14,7 @@ class Profiles extends KlaviyoAPI
     const PEOPLE = 'people';
     const SEARCH = 'search';
     const TIMELINE = 'timeline';
+    const EXCLUSIONS = 'exclusions';
 
     /**
      * Retrieve all data attributes for a person, based on the Klaviyo personID
@@ -147,5 +148,19 @@ class Profiles extends KlaviyoAPI
         $path = sprintf('%s/%s', self::PEOPLE, self::SEARCH);
 
         return $this->v2Request($path, $params);
+    }
+
+    /**
+     * Exclude an email address from all communications.
+     * @link https://apidocs.klaviyo.com/reference/lists-segments#exclude-globally
+     *
+     * @param $email
+     * Email address to exclude.
+     */
+    public function unsubscribeProfileGlobally($email) {
+        $params = $this->createRequestBody([self::EMAIL => $email]);
+        $path = sprintf('%s/%s', self::PEOPLE, self::EXCLUSIONS);
+
+        return $this->v1Request($path, $params, self::HTTP_POST);
     }
 }


### PR DESCRIPTION
This API call is documented under "Lists & Segments" (https://apidocs.klaviyo.com/reference/lists-segments#exclude-globally) but is actually part of the "people" endpoint, so I wasn't sure where to put it; for now I decided it made more sense to put it in `Profiles.php` but I don't feel strongly one way or the other.  I also had to make some modifications to v1 request handling in `KlaviyoAPI.php` due to the way this particular API call apparently wants its requests formatted; I tried to be as minimal as possible with my tweaks but I'm open to critique on the approach.