### PR TITLE
Explicitly set query array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## CHANGELOG
 ### [Unreleased]
+- Fix - Explicitly set curl query array and authentication.
 
 ### [2.3.1]
 - Fix - Use generic exception message if details not available.

--- a/src/KlaviyoAPI.php
+++ b/src/KlaviyoAPI.php
@@ -108,7 +108,7 @@ abstract class KlaviyoAPI
     /**
      * Make private v1 API request
      *
-     * @param $path Endpoint to call
+     * @param string $path Endpoint to call
      * @param array $options API params to add to request
      * @param string $method HTTP method for request
      * @return mixed
@@ -255,12 +255,7 @@ abstract class KlaviyoAPI
      */
     protected function v1Auth( $params )
     {
-        $params = array(
-            self::QUERY => array_merge(
-                $params,
-                array( self::API_KEY_PARAM => $this->private_key )
-            )
-        );
+        $params[self::QUERY][self::API_KEY_PARAM] = $this->private_key;
 
         $params = $this->setUserAgentHeader( $params );
 
@@ -438,6 +433,19 @@ abstract class KlaviyoAPI
     {
         return array(
             'json' => $params
+        );
+    }
+
+    /**
+     * Create query parameter array for CURL.
+     *
+     * @param array $params Key/value pairs to be set as query string.
+     * @return array
+     */
+    protected function createQueryParams($params)
+    {
+        return array(
+            self::QUERY => $params
         );
     }
 

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -42,6 +42,7 @@ class Metrics extends KlaviyoAPI
             self::PAGE=> $page,
             self::COUNT => $count
         ) );
+        $params = $this->createQueryParams($params);
 
         return $this->v1Request( self::METRICS, $params );
     }
@@ -69,14 +70,14 @@ class Metrics extends KlaviyoAPI
     public function getMetricsTimeline( $since = null, $uuid = null, $count = null, $sort = null )
     {
         $params = $this->setSinceParameter( $since, $uuid );
-
-        $params = $this->filterParams( array_merge(
+        $params = $this->filterParams(array_merge(
             $params,
             array(
                 self::COUNT => $count,
                 self::SORT => $sort
             )
-        ) );
+        ));
+        $params = $this->createQueryParams($params);
 
         $path = sprintf( '%s/%s', self::METRICS, self::TIMELINE );
 
@@ -140,7 +141,6 @@ class Metrics extends KlaviyoAPI
     public function getMetricTimelineById($metricID, $since = null, $uuid = null, $count = null, $sort = null)
     {
         $params = $this->setSinceParameter($since, $uuid);
-
         $params = $this->filterParams(
             array_merge(
                 $params,
@@ -150,6 +150,7 @@ class Metrics extends KlaviyoAPI
                 )
             )
         );
+        $params = $this->createQueryParams($params);
 
         $path = sprintf('%s/%s/%s', self::METRIC, $metricID, self::TIMELINE);
         return $this->v1Request($path, $params);
@@ -235,6 +236,7 @@ class Metrics extends KlaviyoAPI
                 self::COUNT => $count,
             )
         );
+        $params = $this->createQueryParams($params);
 
         $path = sprintf('%s/%s/%s', self::METRIC, $metricID, self::EXPORT);
 

--- a/src/Profiles.php
+++ b/src/Profiles.php
@@ -45,8 +45,10 @@ class Profiles extends KlaviyoAPI
      */
     public function updateProfile( $personId, $properties )
     {
+        $params = $this->createQueryParams($properties);
+
         $path = sprintf( '%s/%s', self::PERSON, $personId );
-        return $this->v1Request( $path, $properties, self::HTTP_PUT );
+        return $this->v1Request( $path, $params, self::HTTP_PUT );
     }
 
     /**
@@ -75,7 +77,6 @@ class Profiles extends KlaviyoAPI
     public function getAllProfileMetricsTimeline( $personId, $since = null, $uuid = null, $count = null, $sort = null )
     {
         $params = $this->setSinceParameter( $since, $uuid );
-
         $params = $this->filterParams( array_merge(
             $params,
             array(
@@ -83,6 +84,7 @@ class Profiles extends KlaviyoAPI
                 self::SORT => $sort
             )
         ) );
+        $params = $this->createQueryParams($params);
 
         $path = sprintf( '%s/%s/%s/%s', self::PERSON, $personId, self::METRICS, self::TIMELINE );
 
@@ -118,14 +120,14 @@ class Profiles extends KlaviyoAPI
     public function getProfileMetricTimeline( $personId, $metricId, $since = null, $uuid = null, $count = null, $sort = null )
     {
         $params = $this->setSinceParameter( $since, $uuid );
-
-        $params = $this->filterParams( array_merge(
+        $params = $this->filterParams(array_merge(
             $params,
             array(
                 self::COUNT => $count,
                 self::SORT => $sort
             )
-        ) );
+        ));
+        $params = $this->createQueryParams($params);
 
         $path = sprintf('%s/%s/%s/%s/%s', self::PERSON, $personId, self::METRIC, $metricId, self::TIMELINE );
 


### PR DESCRIPTION
Fix the underlying reason requiring a separate v1 post authentication code path in #62. Explicitly set query parameters in call methods and query string authentication for v1 endpoints.