### PR TITLE
New class to support templates API calls

### DIFF
--- a/src/Templates.php
+++ b/src/Templates.php
@@ -128,11 +128,10 @@ class Templates extends KlaviyoAPI
     public function cloneTemplate($templateId, $name)
     {
         $path = sprintf('%s/%s/%s', self::ENDPOINT_EMAIL_TEMPLATE, $templateId, self::CLONE_PATH);
-
         $params = $this->filterParams( array(
             self::NAME=> $name
         ) );
-        $params = $this->createQueryParams($params);
+        $params = $this->createRequestBody($params);
 
         return $this->v1Request($path, $params, self::HTTP_POST);
     }


### PR DESCRIPTION
I had the need to use the PHP SDK to do API to the Templates endpoint: https://apidocs.klaviyo.com/reference/templates

As this wasn't supported, I wrote the library class.